### PR TITLE
Add ssl support

### DIFF
--- a/lib/websocket-client-simple/client.rb
+++ b/lib/websocket-client-simple/client.rb
@@ -14,6 +14,10 @@ module WebSocket
           @url = url
           uri = URI.parse url
           @socket = TCPSocket.new(uri.host, uri.port || 80)
+          if uri.scheme == 'https'
+            @socket = OpenSSL::SSL::SSLSocket.new(@socket)
+            @socket.connect
+          end
           @handshake = ::WebSocket::Handshake::Client.new :url => url
           @handshaked = false
           frame = ::WebSocket::Frame::Incoming::Client.new


### PR DESCRIPTION
I tried to connect to Socket.IO with SSL (I used Heroku)
But websocket-client-simple says `Errno::ECONNRESET: Connection reset by peer` .
I added ssl support.
