### PR TITLE
Allows Handshake to receive headers, such as Cookie

### DIFF
--- a/lib/websocket-client-simple/client.rb
+++ b/lib/websocket-client-simple/client.rb
@@ -21,7 +21,7 @@ module WebSocket
             @socket = ::OpenSSL::SSL::SSLSocket.new(@socket, ctx)
             @socket.connect
           end
-          @handshake = ::WebSocket::Handshake::Client.new :url => url
+          @handshake = ::WebSocket::Handshake::Client.new :url => url, :headers => options[:headers]
           @handshaked = false
           frame = ::WebSocket::Frame::Incoming::Client.new
           @closed = false


### PR DESCRIPTION
I have a websocket behind SSO that I need to send a cookie to on handshake. This allows me to send headers to your client for the handshake to process. You already accepted options but it was just not given to the handshake.

```ruby
WebSocket::Client::Simple.connect(url, headers: { 'Cookie' => @cookie })
```