### PR TITLE
setting the host name to work with SNI

### DIFF
--- a/lib/websocket-client-simple/client.rb
+++ b/lib/websocket-client-simple/client.rb
@@ -27,6 +27,7 @@ module WebSocket
             cert_store.set_default_paths
             ctx.cert_store = cert_store
             @socket = ::OpenSSL::SSL::SSLSocket.new(@socket, ctx)
+            @socket.hostname = uri.host
             @socket.connect
           end
           @handshake = ::WebSocket::Handshake::Client.new :url => url, :headers => options[:headers]


### PR DESCRIPTION
In order for the SSL Socket to work with SNI the hostname has to be set on the socket.

More info: http://stackoverflow.com/a/34153381
