### PR TITLE
Avoid triggering a segfault due to a read/close race

### DIFF
--- a/lib/websocket-client-simple/client.rb
+++ b/lib/websocket-client-simple/client.rb
@@ -84,11 +84,16 @@ module WebSocket
           if !@pipe_broken
             send nil, :type => :close
           end
+
           @closed = true
+          if @thread
+            Thread.kill @thread
+            Thread.pass while @thread.status
+            @thread = nil
+          end
           @socket.close if @socket
           @socket = nil
           emit :__close
-          Thread.kill @thread if @thread
         end
 
         def open?

--- a/lib/websocket-client-simple/client.rb
+++ b/lib/websocket-client-simple/client.rb
@@ -14,7 +14,7 @@ module WebSocket
         attr_reader :url, :handshake
 
         def connect(url, options={})
-          return if @socket
+          return if @socket ||= nil
           @url = url
           uri = URI.parse url
           @socket = TCPSocket.new(uri.host,


### PR DESCRIPTION
A well-timed pair of threads can trigger a segfault if they call close and read on the same IO at the same time.

It's easy to avoid that with a tiny rearrangement: we can just make sure we shut down the read thread before we close the socket.

No new test, because it's not _that_ easy to trigger on demand.
