### PR TITLE
Non blocking EOF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.gem
 *.rbc
+*.ruby-*
 .bundle
 .config
 .yardoc

--- a/lib/websocket-client-simple/client.rb
+++ b/lib/websocket-client-simple/client.rb
@@ -34,50 +34,30 @@ module WebSocket
             @socket = ::OpenSSL::SSL::SSLSocket.new(@socket, ssl_context)
             @socket.connect
           end
+
           @handshake = ::WebSocket::Handshake::Client.new :url => url, :headers => options[:headers]
           @handshaked = false
           @pipe_broken = false
-          frame = ::WebSocket::Frame::Incoming::Client.new
           @closed = false
           once :__close do |err|
             close
             emit :close, err
           end
 
-          @thread = Thread.new do
-            while !@closed do
-              begin
-                unless recv_data = @socket.getc
-                  sleep 1
-                  next
-                end
-                unless @handshaked
-                  @handshake << recv_data
-                  if @handshake.finished?
-                    @handshaked = true
-                    emit :open
-                  end
-                else
-                  frame << recv_data
-                  while msg = frame.next
-                    emit :message, msg
-                  end
-                end
-              rescue => e
-                emit :error, e
-              end
-            end
-          end
-
-          @socket.write @handshake.to_s
+          handshake
+          @thread = poll
         end
 
-        def send(data, opt={:type => :text})
-          return if !@handshaked or @closed
-          type = opt[:type]
-          frame = ::WebSocket::Frame::Outgoing::Client.new(:data => data, :type => type, :version => @handshake.version)
+        def send_data(data, opt={:type => :text})
+          return if !@handshaked || @closed
+
+          frame = ::WebSocket::Frame::Outgoing::Client.new(:data => data, :type => opt[:type], :version => @handshake.version)
+
           begin
-            @socket.write frame.to_s
+            @socket.write_nonblock(frame.to_s)
+          rescue IO::WaitWritable, Errno::EINTR
+            IO.select(nil, [@socket])
+            retry
           rescue Errno::EPIPE => e
             @pipe_broken = true
             emit :__close, e
@@ -86,22 +66,78 @@ module WebSocket
 
         def close
           return if @closed
-          if !@pipe_broken
-            send nil, :type => :close
-          end
+
+          send_data nil, :type => :close if !@pipe_broken
+          emit :__close
+        ensure
           @closed = true
           @socket.close if @socket
           @socket = nil
-          emit :__close
           Thread.kill @thread if @thread
+        end
+
+        def handshake
+          @socket.write @handshake.to_s
+
+          while !@handshaked
+            begin
+              read_sockets, _, _ = IO.select([@socket], [], [], 10)
+
+              if read_sockets && read_sockets[0]
+                @handshake << @socket.read_nonblock(1024)
+
+                if @socket.respond_to?(:pending) # SSLSocket
+                  @handshake << @socket.read(@socket.pending) while @socket.pending > 0
+                end
+
+                @handshaked = @handshake.finished?
+              end
+            rescue IO::WaitReadable
+              # No op
+            rescue IO::WaitWritable
+              IO.select(nil, [socket])
+              retry
+            end
+          end
+        end
+
+        def poll
+          return Thread.new(@socket) do |socket|
+            frame = ::WebSocket::Frame::Incoming::Client.new
+            emit :open
+
+            while !@closed do
+              read_sockets, _, _ = IO.select([socket], nil, nil, 1)
+
+              if read_sockets && read_sockets[0]
+                begin
+                  frame << socket.read_nonblock(1024)
+
+                  if socket.respond_to?(:pending)
+                    frame << socket.read(socket.pending) while socket.pending > 0
+                  end
+
+                  if msg = frame.next
+                    emit :message, msg
+                    frame = ::WebSocket::Frame::Incoming::Client.new
+                  end
+                rescue IO::WaitReadable
+                  # Nothing
+                rescue IO::WaitWritable
+                  IO.select(nil, [socket])
+                  retry
+                rescue => e
+                  emit :error, e
+                end
+              end
+            end
+          end
         end
 
         def open?
           @handshake.finished? and !@closed
         end
-
       end
-
     end
   end
 end

--- a/lib/websocket-client-simple/client.rb
+++ b/lib/websocket-client-simple/client.rb
@@ -19,6 +19,7 @@ module WebSocket
           uri = URI.parse url
           @socket = TCPSocket.new(uri.host,
                                   uri.port || (uri.scheme == 'wss' ? 443 : 80))
+          @socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
           if ['https', 'wss'].include? uri.scheme
             ssl_context = options[:ssl_context] || begin
               ctx = OpenSSL::SSL::SSLContext.new

--- a/sample/client.rb
+++ b/sample/client.rb
@@ -27,5 +27,5 @@ ws.on :error do |e|
 end
 
 loop do
-  ws.send STDIN.gets.strip
+  ws.send_data STDIN.gets.strip
 end

--- a/sample/echo_server.rb
+++ b/sample/echo_server.rb
@@ -12,7 +12,7 @@ EM::run do
   WebSocket::EventMachine::Server.start(:host => "0.0.0.0", :port => PORT) do |ws|
     ws.onopen do
       sid = @channel.subscribe do |mes|
-        ws.send mes
+        ws.send_data mes
       end
       puts "<#{sid}> connect"
 

--- a/test/echo_server.rb
+++ b/test/echo_server.rb
@@ -4,7 +4,7 @@ module EchoServer
       @channel = EM::Channel.new
       ws.onopen do
         sid = @channel.subscribe do |mes|
-          ws.send mes  # echo to client
+          ws.send_data mes  # echo to client
         end
         ws.onmessage do |msg|
           @channel.push msg

--- a/test/test_connect_block.rb
+++ b/test/test_connect_block.rb
@@ -13,7 +13,7 @@ class TestWebSocketClientSimple < MiniTest::Test
       EM::add_timer 1 do
         WebSocket::Client::Simple.connect EchoServer.url do |client|
           client.on :open do
-            client.send "hello world"
+            client.send_data "hello world"
           end
 
           client.on :message do |msg|

--- a/test/test_websocket_client_simple.rb
+++ b/test/test_websocket_client_simple.rb
@@ -27,7 +27,7 @@ class TestWebSocketClientSimple < MiniTest::Test
 
         client1.on :open do
           msgs.each do |m|
-            client1.send m
+            client1.send_data m
           end
         end
 


### PR DESCRIPTION
This is a follow-on PR to issue #23 (non_blocking support) resolving issue #24 (:close not being triggered) in that scenario. Basically while running non_blocking logic, we've encountered an issue where the server closes the connection resulting in the socket.read_nonblock call failing indefinetly (the error being EOFError with the logic handling it by emitting ':error' but doing nothing beyond this.

This patch resolves this by handling this specific error to close the websocket. Also it slightly reworks the 'close' logic to simplify the event emitter logic as that callback was never being invoked in this scenario. Now the __close event was removed and instead all the corresponding invokers simply call "close" which emits the :close event (with error).

To use simply apply abrandoned/non_block then the patch contained here 